### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/lkrmelu19920434/5192af3a-824f-4e2c-8e2f-093666ed3341/79ac2c93-e4ac-4050-aa4d-43f814bc9e69/_apis/work/boardbadge/72982987-89b0-40c2-8741-08eadad90ca3)](https://dev.azure.com/lkrmelu19920434/5192af3a-824f-4e2c-8e2f-093666ed3341/_boards/board/t/79ac2c93-e4ac-4050-aa4d-43f814bc9e69/Microsoft.RequirementCategory)
 <img src="https://platform.avideo.com/website/assets/151/images/avideo_platform.png"/>
 
 ## Audio Video Platform


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/lkrmelu19920434/5192af3a-824f-4e2c-8e2f-093666ed3341/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.